### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 :spring_version: current
 :spring_boot_version: 1.5.10.RELEASE
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:DirtiesContext: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/test/annotation/DirtiesContext.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:DirtiesContext: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/test/annotation/DirtiesContext.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -122,7 +122,7 @@ The `@SpringBootTest` annotation tells Spring Boot to go and look for a main con
 include::complete/src/test/java/hello/SmokeTest.java[]
 ----
 
-The `@Autowired` annotation is interpreted by the Spring and the controller is injected before the test methods are run. We are using http://joel-costigliola.github.io/assertj/[AssertJ] (`assertThat()` etc.) to express the test assertions.
+The `@Autowired` annotation is interpreted by the Spring and the controller is injected before the test methods are run. We are using https://joel-costigliola.github.io/assertj/[AssertJ] (`assertThat()` etc.) to express the test assertions.
 
 NOTE: A nice feature of the Spring Test support is that the application context is cached in between tests, so if you have multiple methods in a test case, or multiple test cases with the same configuration, they only incur the cost of starting the application once. You can control the cache using the {DirtiesContext}[`@DirtiesContext`] annotation.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://joel-costigliola.github.io/assertj/ with 1 occurrences migrated to:  
  https://joel-costigliola.github.io/assertj/ ([https](https://joel-costigliola.github.io/assertj/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost:8080 with 1 occurrences