### PR TITLE
Fix #19 : wrong code sample in Test the Application

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,7 @@ application context cannot start. The following listing (from
 ====
 [source,java]
 ----
-include::initial/src/test/java/com/example/testingweb/TestingWebApplicationTest.java[]
+include::initial/src/test/java/com/example/testingweb/TestingWebApplicationTests.java[]
 ----
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,7 @@ application context cannot start. The following listing (from
 ====
 [source,java]
 ----
-include::complete/src/test/java/com/example/testingweb/TestingWebApplicationTest.java[]
+include::initial/src/test/java/com/example/testingweb/TestingWebApplicationTest.java[]
 ----
 ====
 


### PR DESCRIPTION
This PR fixes #19.  
The code block that was used was the final form instead of the initial form. So the `contextLoads` simple test was illustrated with a full `mockMVC` test.