### PR TITLE
Redundant SpringRunner import deletion

### DIFF
--- a/initial/src/test/java/com/example/testingweb/TestingWebApplicationTests.java
+++ b/initial/src/test/java/com/example/testingweb/TestingWebApplicationTests.java
@@ -3,7 +3,6 @@ package com.example.testingweb;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 @SpringBootTest
 public class TestingWebApplicationTests {


### PR DESCRIPTION
redundant SpringRunner import from TestingWebApplicationTests class
this import also exists on the GSG page.