### PR TITLE
Fixed typo in test method name

### DIFF
--- a/complete/src/test/java/com/example/testingweb/SmokeTest.java
+++ b/complete/src/test/java/com/example/testingweb/SmokeTest.java
@@ -14,7 +14,7 @@ public class SmokeTest {
 	private HomeController controller;
 
 	@Test
-	public void contexLoads() throws Exception {
+	public void contextLoads() throws Exception {
 		assertThat(controller).isNotNull();
 	}
 }


### PR DESCRIPTION
Found a typo in the test method name while going through docs. Fixed it.