### PR TITLE
fix: typo and improve description

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,8 +87,8 @@ settings, other beans, and various property settings.
 such as setting up a `DispatcherServlet`. Spring Boot adds it  automatically when it sees
 `spring-webmvc` on the classpath.
 - `@ComponentScan`: Tells Spring to look for other components, configurations, and
-services in the the `com.example.testingweb` package, letting it find the
-`HelloController` class.
+services in the package where your annotated `TestingWebApplication` class resides
+(`com.example.testingweb`), letting it find the `com.example.testingweb.HelloController`.
 
 The `main()` method uses Spring Boot's `SpringApplication.run()` method to launch an
 application. Did you notice that there is not a single line of XML? There is no `web.xml`


### PR DESCRIPTION
This PR fixes the typo with `"the the"`, and elaborated the description for `@ComponentScan`.

**Motivation** 
For updating the description of `@ComponentScan`. Beginners, like me, uses Spring guides, and it was confusing as to why the `com.example.testingweb` package gets picked, and the reason it was picked as  the package of the class annotated with `@SpringBootApplication`.

Feel free to correct me, to improve this part. This can also open new idea if we can add new macro (https://github.com/spring-guides/getting-started-macros) for the `@SpringBootApplication` annotation.
They could be found in other guides (not exhaustive list):
* https://spring.io/guides/gs/rest-service/
* https://spring.io/guides/gs/uploading-files/
* https://spring.io/guides/gs/accessing-data-neo4j/