### PR TITLE
fix: test visibility

### DIFF
--- a/complete/src/test/java/com/example/testingweb/HttpRequestTest.java
+++ b/complete/src/test/java/com/example/testingweb/HttpRequestTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class HttpRequestTest {
+class HttpRequestTest {
 
 	@LocalServerPort
 	private int port;
@@ -20,7 +20,7 @@ public class HttpRequestTest {
 	private TestRestTemplate restTemplate;
 
 	@Test
-	public void greetingShouldReturnDefaultMessage() throws Exception {
+	void greetingShouldReturnDefaultMessage() throws Exception {
 		assertThat(this.restTemplate.getForObject("http://localhost:" + port + "/",
 				String.class)).contains("Hello, World");
 	}

--- a/complete/src/test/java/com/example/testingweb/SmokeTest.java
+++ b/complete/src/test/java/com/example/testingweb/SmokeTest.java
@@ -8,13 +8,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class SmokeTest {
+class SmokeTest {
 
 	@Autowired
 	private HomeController controller;
 
 	@Test
-	public void contextLoads() throws Exception {
+	void contextLoads() throws Exception {
 		assertThat(controller).isNotNull();
 	}
 }

--- a/complete/src/test/java/com/example/testingweb/TestingWebApplicationTest.java
+++ b/complete/src/test/java/com/example/testingweb/TestingWebApplicationTest.java
@@ -15,13 +15,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class TestingWebApplicationTest {
+class TestingWebApplicationTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
-	public void shouldReturnDefaultMessage() throws Exception {
+	void shouldReturnDefaultMessage() throws Exception {
 		this.mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk())
 				.andExpect(content().string(containsString("Hello, World")));
 	}

--- a/complete/src/test/java/com/example/testingweb/WebLayerTest.java
+++ b/complete/src/test/java/com/example/testingweb/WebLayerTest.java
@@ -14,13 +14,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(HomeController.class)
 //tag::test[]
-public class WebLayerTest {
+class WebLayerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
-	public void shouldReturnDefaultMessage() throws Exception {
+	void shouldReturnDefaultMessage() throws Exception {
 		this.mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk())
 				.andExpect(content().string(containsString("Hello, World")));
 	}

--- a/complete/src/test/java/com/example/testingweb/WebMockTest.java
+++ b/complete/src/test/java/com/example/testingweb/WebMockTest.java
@@ -15,7 +15,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(GreetingController.class)
-public class WebMockTest {
+class WebMockTest {
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -24,7 +24,7 @@ public class WebMockTest {
 	private GreetingService service;
 
 	@Test
-	public void greetingShouldReturnMessageFromService() throws Exception {
+	void greetingShouldReturnMessageFromService() throws Exception {
 		when(service.greet()).thenReturn("Hello, Mock");
 		this.mockMvc.perform(get("/greeting")).andDo(print()).andExpect(status().isOk())
 				.andExpect(content().string(containsString("Hello, Mock")));

--- a/initial/src/test/java/com/example/testingweb/TestingWebApplicationTests.java
+++ b/initial/src/test/java/com/example/testingweb/TestingWebApplicationTests.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class TestingWebApplicationTests {
+class TestingWebApplicationTests {
 
 	@Test
-	public void contextLoads() {
+	void contextLoads() {
 	}
 
 }


### PR DESCRIPTION
This PR removes `public` access modifier to the test methods and classes, to prefer package-private access modifier.

**Motivation**
As this is a testing section, and we're already using JUnit 5 here. JUnit 5 is more tolerant with the visibility of testing classes and methods. The package-private access modifier is preferred over `public` ones, this can be found in their [user guide](https://junit.org/junit5/docs/current/user-guide/#writing-tests-classes-and-methods).

> It is generally recommended to omit the public modifier for test classes, test methods, and lifecycle methods unless there is a technical reason for doing so – for example, when a test class is extended by a test class in another package. Another technical reason for making classes and methods public is to simplify testing on the module path when using the Java Module System.

**initial**
```
cd initial
./gradlew test                                                                                                                                                                                       

BUILD SUCCESSFUL in 967ms
4 actionable tasks: 4 up-to-date
```

**complete**
```
cd complete
./gradlew test                                                                                                                                                                                       

BUILD SUCCESSFUL in 873ms
3 actionable tasks: 3 up-to-date
```