### PR TITLE
fix: Corrected the AsciiDoc syntax to properly display spring code.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -181,8 +181,7 @@ listing (from `src/test/java/com/example/testingweb/WebLayerTest.java`) shows:
 ====
 [source,java]
 ----
-@WebMvcTest
-include::complete/src/test/java/com/example/testingweb/WebLayerTest.java
+include::complete/src/test/java/com/example/testingweb/WebLayerTest.java[]
 ----
 ====
 

--- a/complete/src/test/java/com/example/testingweb/WebLayerTest.java
+++ b/complete/src/test/java/com/example/testingweb/WebLayerTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(HomeController.class)
-//tag::test[]
 class WebLayerTest {
 
 	@Autowired
@@ -25,4 +24,3 @@ class WebLayerTest {
 				.andExpect(content().string(containsString("Hello, World")));
 	}
 }
-//end::test[]


### PR DESCRIPTION
There is a code snippet, resembling AsciiDoc syntax, that is confusing me as I follow the guide "[Testing the Web Layer](https://spring.io/guides/gs/testing-web/)". The actual spring code snippet does not seem to be properly rendered.

Here is a comparison between the version before and after the fix.

Before:

```
@WebMvcTest
include::complete/src/test/java/com/example/testingweb/WebLayerTest.java
```
After:

```
package com.example.testingweb;

import static org.hamcrest.Matchers.containsString;
import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

import org.junit.jupiter.api.Test;

import org.springframework.beans.factory.annotation.Autowired;
import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
import org.springframework.test.web.servlet.MockMvc;

@WebMvcTest(HomeController.class)
class WebLayerTest {

	@Autowired
	private MockMvc mockMvc;

	@Test
	void shouldReturnDefaultMessage() throws Exception {
		this.mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk())
				.andExpect(content().string(containsString("Hello, World")));
	}
}
```